### PR TITLE
Feature/transactions filters with ransack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,9 @@ gem "aws-sdk-s3"
 # Dotenv for Rails. Loads environment variables from .env into ENV in Rails.
 gem "dotenv-rails"
 
+# Ransack
+gem "ransack"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,6 +252,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
+    ransack (4.2.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rbs (2.8.4)
     rdoc (6.7.0)
       psych (>= 4.0.0)
@@ -381,6 +385,7 @@ DEPENDENCIES
   pry-rails
   puma (>= 5.0)
   rails (~> 7.1.1)
+  ransack
   redis (>= 4.0.1)
   rspec-rails
   rubocop-rails

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -5,7 +5,10 @@ class TransactionsController < ApplicationController
   before_action :set_transaction, only: %i[show edit update destroy]
 
   def index
-    @transactions = Transaction.for_user(current_user)
+    @q = Transaction.ransack(params[:q])
+    @transactions = @q.result(distinct: true).for_user(current_user)
+    @accounts = current_user.accounts
+    @categories = Category.joins(:transactions).where(transactions: { account_id: current_user.accounts.ids }).distinct
   end
 
   def show; end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -17,4 +17,12 @@ class Transaction < ApplicationRecord
   scope :income, -> { where(transaction_type: "income") }
   scope :expense, -> { where(transaction_type: "expense") }
   scope :for_user, ->(user) { joins(:account).where(accounts: { user_id: user.id }).order(due_date: :desc) }
+
+  def self.ransackable_attributes(*)
+    %w[account_id amount category_id created_at description due_date id id_value status transaction_type updated_at]
+  end
+
+  def self.ransackable_associations(*)
+    %w[account category]
+  end
 end

--- a/app/views/transactions/_search_form.html.erb
+++ b/app/views/transactions/_search_form.html.erb
@@ -1,0 +1,53 @@
+<div class="mb-4">
+  <details class="border border-gray-300 rounded-md">
+    <summary class="cursor-pointer bg-gray-100 px-4 py-2 text-base font-medium text-gray-700 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2">
+      <%= I18n.t("views.transaction.actions.show_filters") %>
+    </summary>
+    <div class="mt-4 px-4 py-2">
+      <%= search_form_for @q, url: transactions_path, method: :get, local: true, class: "space-y-4" do |f| %>
+        <table class="w-full">
+          <thead>
+            <tr>
+              <th class="text-left text-sm font-medium text-gray-700"><%= f.label :description_cont, t("attributes.description") %></th>
+              <th class="text-left text-sm font-medium text-gray-700"><%= f.label :transaction_type_eq, t("attributes.transaction_type") %></th>
+              <th class="text-left text-sm font-medium text-gray-700"><%= f.label :due_date_gteq, "Data Venc. Inicial" %></th>
+              <th class="text-left text-sm font-medium text-gray-700"><%= f.label :due_date_lteq, "Data Venc. Final" %></th>
+              <th class="text-left text-sm font-medium text-gray-700"><%= f.label :account_id_eq, t("attributes.account_id") %></th>
+              <th class="text-left text-sm font-medium text-gray-700"><%= f.label :category_id_eq, t("attributes.category_id") %></th>
+              <th class="text-left text-sm font-medium text-gray-700"><%= f.label :status_eq, t("attributes.status") %></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>
+                <%= f.search_field :description_cont, class: "mt-1 block w-full sm:w-32 shadow-sm sm:text-sm border-gray-300 rounded-md" %>
+              </td>
+              <td>
+                <%= f.select :transaction_type_eq, options_for_select(Transaction.transaction_types.map { |key, _value| [I18n.t("attributes.transaction_types.#{key}"), key] }), include_blank: "Selecione...", class: "mt-1 block w-full sm:w-32 shadow-sm sm:text-sm border-gray-300 rounded-md" %>
+              </td>
+              <td>
+                <%= f.date_field :due_date_gteq, value: (params[:due_date_gteq] || Time.zone.today.beginning_of_month.strftime("%Y-%m-%d")), class: "mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" %>
+              </td>
+              <td>
+                <%= f.date_field :due_date_lteq, value: (params[:due_date_lteq] || Time.zone.today.strftime("%Y-%m-%d")), class: "mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" %>
+              </td>
+              <td>
+                <%= f.select :account_id_eq, options_for_select(@accounts.map { |account| [account.name, account.id] }), include_blank: "Selecione...", class: "mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" %>
+              </td>
+              <td>
+                <%= f.select :category_id_eq, options_for_select(@categories.map { |category| [category.name, category.id] }), include_blank: "Selecione...", class: "mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" %>
+              </td>
+              <td>
+                <%= f.select :status_eq, options_for_select(Transaction.statuses.map { |key, _value| [I18n.t("attributes.statuses.#{key}"), key] }), include_blank: "Selecione...", class: "mt-1 block w-full sm:w-32 shadow-sm sm:text-sm border-gray-300 rounded-md" %>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <div class="flex justify-start mt-4 space-x-4">
+          <%= f.submit t("views.transaction.actions.filter"), class: "inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-base font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2" %>
+          <%= link_to t("views.transaction.actions.clear"), transactions_path, class: "inline-flex items-center justify-center rounded-md border border-gray-300 bg-gray-100 px-4 py-2 text-base font-medium text-gray-700 shadow-sm hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2" %>
+        </div>
+      <% end %>
+    </div>
+  </details>
+</div>

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -2,17 +2,18 @@
 <div class="flex justify-end mb-4">
   <%= link_to I18n.t("views.transaction.actions.new"), new_transaction_path, class: "inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-base font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2" %>
 </div>
+<%= render "search_form" %>
 <div class="overflow-x-auto relative shadow-lg sm:rounded-lg">
   <table class="w-full text-sm text-left text-gray-500">
     <thead class="text-xs text-gray-700 uppercase bg-gray-50">
       <tr>
-        <th scope="col" class="py-3 px-6 text-center"><%= t("attributes.description") %></th>
-        <th scope="col" class="py-3 px-6 text-center"><%= t("attributes.amount") %></th>
-        <th scope="col" class="py-3 px-6 text-center"><%= t("attributes.transaction_type") %></th>
-        <th scope="col" class="py-3 px-6 text-center"><%= t("attributes.due_date") %></th>
-        <th scope="col" class="py-3 px-6 text-center"><%= t("attributes.account_id") %></th>
-        <th scope="col" class="py-3 px-6 text-center"><%= t("attributes.category_id") %></th>
-        <th scope="col" class="py-3 px-6 text-center"><%= t("attributes.status") %></th>
+        <th scope="col" class="py-3 px-6 text-center"><%= sort_link(@q, :description, t("attributes.description")) %></th>
+        <th scope="col" class="py-3 px-6 text-center"><%= sort_link(@q, :amount, t("attributes.amount")) %></th>
+        <th scope="col" class="py-3 px-6 text-center"><%= sort_link(@q, :transaction_type, t("attributes.transaction_type")) %></th>
+        <th scope="col" class="py-3 px-6 text-center"><%= sort_link(@q, :due_date, t("attributes.due_date")) %></th>
+        <th scope="col" class="py-3 px-6 text-center"><%= sort_link(@q, :account_id, t("attributes.account_id")) %></th>
+        <th scope="col" class="py-3 px-6 text-center"><%= sort_link(@q, :category_id, t("attributes.category_id")) %></th>
+        <th scope="col" class="py-3 px-6 text-center"><%= sort_link(@q, :status, t("attributes.status")) %></th>
         <th scope="col" class="py-3 px-6 text-center"><%= t("helpers.table.actions") %></th>
       </tr>
     </thead>

--- a/config/locales/views/transaction/pt-BR.yml
+++ b/config/locales/views/transaction/pt-BR.yml
@@ -8,6 +8,9 @@ pt-BR:
         show: "Ver transação"
         destroy: "Deletar transação"
         details: "Detalhes da Transação"
+        filter: "Filtrar"
+        clear: "Limpar"
+        show_filters: "Exibir Filtros"
       notice:
         create: "Transação criada com sucesso"
         edit: "Transação atualizada com sucesso"


### PR DESCRIPTION
- Add gem ransack
- Update index action in TransactionsController to use ransack for filtering and include user-specific accounts and categories
- Add ransackable_attributes and ransackable_associations methods to Transaction model for ransack support
- Config translations to filters creating partial search_form and modify transaction index to add filters table

![Captura de tela de 2024-08-28 18-58-15](https://github.com/user-attachments/assets/907d6419-01db-4de5-9f1f-c77806552088)